### PR TITLE
Mailchimp - Shopware default language set

### DIFF
--- a/shopware_to_mailchimp/recipe.json
+++ b/shopware_to_mailchimp/recipe.json
@@ -15,6 +15,7 @@
                 },
                 "step_3": {
                     "mapper": {
+                    	"language": "de",
                         "email": "{{email}}",
                         "email_type": "html",
                         "firstName": "{{first}}",


### PR DESCRIPTION
Now mailchimp recipe automatically set language to 'de'
